### PR TITLE
Version 1.4.0

### DIFF
--- a/banking/statements/nordea/parser.py
+++ b/banking/statements/nordea/parser.py
@@ -1,4 +1,5 @@
 from ofxstatement.parser import CsvStatementParser
+from hashlib import md5
 import csv
 
 from . import TRANSACTION_TYPES
@@ -54,4 +55,8 @@ class NordeaCsvStatementParser(CsvStatementParser):
 
         # fill statement line according to mappings
         sl = super(NordeaCsvStatementParser, self).parse_record(line)
+
+        # generate a unique id by combining date, payee, amount and reference number
+        sl.id = md5(f"{line[0]}-{sl.payee}-{sl.amount}-{sl.refnum}".encode()).hexdigest()
+
         return sl

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,5 +1,11 @@
 Changelog
 =========
+1.4.0
+-----
+
+- Since version 0.6.5 ofxstatement requires a statement line to have either id, refnum or check_no. To avoid failing
+  the conversion, there's now a unique MD5 hashed ID computed from the date, payee, amount and refnum.
+
 1.3.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.0'
+version = '1.4.0'
 
 setup(name='banking.statements.nordea',
       version=version,


### PR DESCRIPTION
Since version 0.6.5 ofxstatement requires a statement line to have eitherid, refnum or check_no (see commit https://github.com/kedder/ofxstatement/commit/e536af21efbfadff56b59cd1938ae822b101aa90#diff-10d272377037b6a0f0c3f35a1cd4f582fa58e5ebe0aa7632df73eafd3dddef0aR152).

To avoid failing the conversion, there's now a unique MD5 hashed ID computed from the date, payee, amount and refnum.